### PR TITLE
[refactor] Ball 객체 역할 분리 및 MergeManager 시스템 구축

### DIFF
--- a/Assets/Scripts/BallCollisionSensor.cs
+++ b/Assets/Scripts/BallCollisionSensor.cs
@@ -1,0 +1,78 @@
+using UnityEngine;
+using JusticeScale.Scripts.Scales;
+
+//자동으로 Ball 스크립트도 붙여줌
+[RequireComponent(typeof(Ball))]
+public class BallCollisionSensor : MonoBehaviour
+{
+    private Ball _ball;
+
+    private void Awake()
+    {
+        _ball = GetComponent<Ball>();
+    }
+
+    public void RegisterScale(Scale detectedScale)
+    {
+        if (GameManager.Instance.isGameOver) return;
+
+        if (_ball.CurrentScale == null)
+        {
+            //ball의 데이터 갱신
+            _ball.SetScale(detectedScale);
+
+            float myMass = _ball.Rigidbody.mass;
+            float myScale = transform.localScale.x;
+            ScoreManager.Instance.AddScore(_ball.ballLevel, myMass, myScale, false);
+
+            if (_ball.ballLevel == 5)
+            {
+                GameManager.Instance.CheckBlackHoleCondition();
+            }
+        }
+        
+        else if (_ball.CurrentScale != detectedScale)
+        {
+            GameManager.Instance.GameOver("Ball moves another scale");
+            GameManager.Instance.LoseLife("Ball moved to another scale");
+        }
+    }
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        if (_ball.IsMerging) return;
+
+        Ball otherBall = collision.collider.attachedRigidbody?.GetComponent<Ball>();
+
+        if (otherBall != null)
+        {
+            CheckScaleConsistency(otherBall);
+
+            if (GameManager.Instance.isGameOver) return;
+
+            if (otherBall.ballLevel == _ball.ballLevel)
+            {
+                // 중복 충돌 방지
+                if (this.gameObject.GetInstanceID() > otherBall.gameObject.GetInstanceID())
+                {
+                    MergeManager.Instance.TryMerge(_ball, otherBall);
+                }
+            }
+        }
+    }
+
+    private void CheckScaleConsistency(Ball otherBall)
+    {
+        if (otherBall.CurrentScale == null) return;
+
+        if (_ball.CurrentScale == null)
+        {
+            RegisterScale(otherBall.CurrentScale);
+        }
+        else if (_ball.CurrentScale != otherBall.CurrentScale)
+        {
+            GameManager.Instance.GameOver("Ball moved to another scale(Stack Collision)");
+            GameManager.Instance.LoseLife("Ball moved to another scale(Stack Collision)");
+        }
+    }
+}

--- a/Assets/Scripts/BallCollisionSensor.cs.meta
+++ b/Assets/Scripts/BallCollisionSensor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6bfa067f752df49719fa59c5b66e8c63

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -113,7 +113,7 @@ public class GameManager : SingletonBehaviour<GameManager>
                 if(ballScript != null)
                 {
                     int poolSize = (ballScript.ballLevel <= 2) ? 30 : 10;
-                    PoolType type = (PoolType)(ballScript.ballLevel - 1);
+                    PoolType type = ballScript.myPoolType; 
                     PoolManager.Instance.CreatePool(type, data.prefab, poolSize);
                 }
             }
@@ -169,7 +169,7 @@ public class GameManager : SingletonBehaviour<GameManager>
         if(selectedBallPrefab != null)
         {
             Ball ballPrefabScript = selectedBallPrefab.GetComponent<Ball>();
-            PoolType type = (PoolType)(ballPrefabScript.ballLevel - 1); 
+            PoolType type = ballPrefabScript.myPoolType; 
             PoolManager.Instance.Spawn<Ball>(type, worldPosition, Quaternion.identity);
         }
         SetNextBall();
@@ -213,11 +213,11 @@ public class GameManager : SingletonBehaviour<GameManager>
                 Destroy(rb);
             }
 
-            Collider[] cols = _currentPreviewObject.GetComponentsInChildren<Collider>(true);
-            foreach(Collider col in cols)
+            BallCollisionSensor[] sensorScripts = _currentPreviewObject.GetComponentsInChildren<BallCollisionSensor>(true);
+            foreach(BallCollisionSensor sensor in sensorScripts)
             {
-                col.enabled = false;
-                Destroy(col);
+                sensor.enabled = false;
+                Destroy(sensor);
             }
 
             Ball[] ballScripts = _currentPreviewObject.GetComponentsInChildren<Ball>(true);
@@ -378,7 +378,7 @@ public class GameManager : SingletonBehaviour<GameManager>
 
         StartCoroutine(AnimateBlackHoleAbsorption(star1, star2));
 
-        // 블랙홀 발동과 동시에 100% 피버타임
+        // 블랙홀 발동과 동시에 피버타임
         if (!isFeverTime)
         {
             currentFever = 100f; 
@@ -395,10 +395,10 @@ public class GameManager : SingletonBehaviour<GameManager>
             Destroy(effect, 7f); 
         }
         if (star1 != null) 
-            PoolManager.Instance.ReturnObject((PoolType)(star1.ballLevel), star1.gameObject);
+            PoolManager.Instance.ReturnObject(star1.myPoolType, star1.gameObject);
         
         if (star2 != null) 
-            PoolManager.Instance.ReturnObject((PoolType)(star2.ballLevel), star2.gameObject);
+            PoolManager.Instance.ReturnObject(star2.myPoolType, star2.gameObject);
     }
 
     private System.Collections.IEnumerator AnimateBlackHoleAbsorption(Ball star1, Ball star2)

--- a/Assets/Scripts/MergeManager.cs
+++ b/Assets/Scripts/MergeManager.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+public class MergeManager : SingletonBehaviour<MergeManager>
+{
+    public void TryMerge(Ball firstBall, Ball secondBall)
+    {
+        // 어느 한 쪽이 이미 병합중일 경우
+        if(firstBall.IsMerging || secondBall.IsMerging) return;
+
+        firstBall.SetMerging(true);
+        secondBall.SetMerging(true);
+
+        // 충돌 지점 계산
+        Vector3 spawnPos = (firstBall.transform.position + secondBall.transform.position) / 2f;
+
+        if (firstBall.nextLevelPrefab != null)
+        {
+            int nextLevel = firstBall.ballLevel + 1;
+            PoolType nextPoolType = firstBall.nextLevelPrefab.GetComponent<Ball>().myPoolType;
+
+            Ball newBall = PoolManager.Instance.Spawn<Ball>(nextPoolType, spawnPos, Quaternion.identity);
+
+            if (newBall != null)
+            {
+                BallCollisionSensor sensor = newBall.GetComponent<BallCollisionSensor>();
+
+                if(sensor != null && firstBall.CurrentScale != null)
+                {
+                    sensor.RegisterScale(firstBall.CurrentScale);
+                }
+                else
+                {
+                    float newMass = newBall.Rigidbody.mass;
+                    float newScale = newBall.transform.localScale.x;
+                
+                    ScoreManager.Instance.AddScore(nextLevel, newMass, newScale, GameManager.Instance.isFeverTime);
+                }
+            }
+        }
+        PoolManager.Instance.ReturnObject(firstBall.myPoolType, firstBall.gameObject);
+        PoolManager.Instance.ReturnObject(secondBall.myPoolType, secondBall.gameObject);
+    }
+}

--- a/Assets/Scripts/MergeManager.cs.meta
+++ b/Assets/Scripts/MergeManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a604d8ecc61b44182bf991f392cba3c9


### PR DESCRIPTION
## 개요
`Ball`의 단일 책임 원칙(SRP) 준수를 위해 충돌 감지와 병합 로직을 분리하여 `MergeManager`와 `BallCollisionSensor`를 구현했습니다. 이를 통해 중앙 통제 가능한 병합 시스템을 구축했습니다.

> Resolves #23 

## 작업 내용

### 1. 컴포넌트 분리 및 캡슐화 (System)
- `MergeManager.cs` : 두 객체의 병합 절차, 스폰, 잉여 객체 반납을 전담하는 싱글톤 매니저 도입
- `BallCollisionSensor.cs` : 물리적 충돌 감지 및 저울 등록 후 병합을 매니저에게 요청하도록 구현
- `Ball.cs` : Setter(SetMerging, SetScale)와 프로퍼티를 활용한 캡슐화 적용

## 테스트 계획
**준비**
1. 씬 내 빈 게임 오브젝트 생성 후 `MergeManager` 컴포넌트 부착
2. 프로젝트 내 모든 공 프리팹에 `BallCollisionSensor` 컴포넌트 일괄 부착 확인
3. `GameManager` 인스펙터의 `Ball List` 배열에 모든 레벨의 공이 모두 빠짐없이 등록되었는지 확인

**검증 절차**
1. **스폰 및 프리뷰 에러 확인** : 게임 실행 시 프리뷰 객체가 정상 생성/삭제되며 의존성 에러(`Can't remove Ball`)가 발생하지 않는지 확인.
2. **충돌 및 병합 확인** : 같은 레벨의 공 충돌 시 `BallCollisionSensor`가 `MergeManager`를 정상 호출하여 새 공이 스폰되는지 확인.
3. **Enum 타입 에러 검증** : 고레벨 공(레벨 4 + 레벨 4 -> 레벨 5 최고레벨)으로 병합 시 에러(`Ball_5 pool is not here` 등) 없이 정상적으로 합쳐지는지 확인.
4. **점수 동기화 확인** : 병합 시 새로 생성된 공이 뱉어내는 점수(피버 보너스 포함)가 UI에 즉각 반영되는지 확인.