### PR TITLE
[Feat] 씬 자동 저장 시스템 구성

### DIFF
--- a/Assets/Editor/AutoSaveTool.cs
+++ b/Assets/Editor/AutoSaveTool.cs
@@ -1,0 +1,144 @@
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+public class AutoSaveTool : EditorWindow
+{
+    private const string PREF_KEY_ENABLED = "AutoSave_Enabled";
+    private const string PREF_KEY_INTERVAL = "AutoSave_Interval";
+
+    private bool _isAutoSaveEnabled = true;
+    private float _saveIntervalMinutes = 5f;
+    private double _lastSaveTime;
+
+    // 최소 저장 시간 간격 (1분)
+    private float _minSaveTime = 1f;
+
+    private int _lastDisplayedSeconds = -1;
+
+    // 상단 메뉴 등록
+    [MenuItem("Tools/Auto Save Settings")]
+    public static void ShowWindow()
+    {
+        // 최소 창 크기 고정
+        AutoSaveTool window = GetWindow<AutoSaveTool>("씬 자동 저장 설정");
+        window.minSize = new Vector2(300, 200);
+    }
+
+    private void OnEnable()
+    {
+        // 유니티가 꺼져도 해당 조건은 유지
+        _isAutoSaveEnabled = EditorPrefs.GetBool("AutoSave_Enabled", true);
+        _saveIntervalMinutes = EditorPrefs.GetFloat("AutoSave_Interval", 5f);
+        _lastSaveTime = EditorApplication.timeSinceStartup;
+        
+        EditorApplication.update += OnEditorUpdate;
+    }
+
+    private void OnDisable()
+    {
+        EditorApplication.update -= OnEditorUpdate;
+    }
+
+    private void LoadSettings()
+    {
+        _isAutoSaveEnabled = EditorPrefs.GetBool(PREF_KEY_ENABLED, true);
+        _saveIntervalMinutes = EditorPrefs.GetFloat(PREF_KEY_INTERVAL, 5f);
+    }
+
+    private void SaveSettings()
+    {
+        EditorPrefs.SetBool(PREF_KEY_ENABLED, _isAutoSaveEnabled);
+        EditorPrefs.SetFloat(PREF_KEY_INTERVAL, _saveIntervalMinutes);
+    }
+
+    private void OnGUI()
+    {
+        DrawHeader();
+        DrawSettings();
+        DrawStatus();
+    }
+    
+    private void DrawHeader()
+    {
+        GUILayout.Space(10);
+        GUILayout.Label("씬 자동 저장 컨트롤러", EditorStyles.boldLabel);
+        GUILayout.Space(10);
+    }
+
+    private void DrawSettings()
+    {
+        // 실제로 조작 가했을 때만 체크
+        EditorGUI.BeginChangeCheck();
+        
+        _isAutoSaveEnabled = EditorGUILayout.Toggle("자동 저장 켜기", _isAutoSaveEnabled);
+        _saveIntervalMinutes = EditorGUILayout.FloatField("저장 주기 (분)", _saveIntervalMinutes);
+        _saveIntervalMinutes = Mathf.Max(_minSaveTime, _saveIntervalMinutes);
+
+        if (EditorGUI.EndChangeCheck())
+        {
+            SaveSettings();
+            //타이머 리셋
+            _lastSaveTime = EditorApplication.timeSinceStartup;
+        }
+    }
+
+    private void DrawStatus()
+    {
+        GUILayout.Space(20);
+
+        if (_isAutoSaveEnabled)
+        {
+            double timeRemaining = GetTimeRemaining();
+            GUILayout.Label($"다음 자동 저장까지: {Mathf.Max(0, (float)timeRemaining):F0}초", EditorStyles.helpBox);
+        }
+        else
+        {
+            GUILayout.Label("자동 저장 기능이 정지되었습니다.", EditorStyles.helpBox);
+        }
+
+        GUILayout.Space(10);
+
+        if (GUILayout.Button("지금 즉시 저장 (수동)", GUILayout.Height(35)))
+        {
+            ExecuteSave();
+        }
+    }
+
+    // 남은 시간(초) 계산 함수
+    private double GetTimeRemaining()
+    {
+        double timeSinceLastSave = EditorApplication.timeSinceStartup - _lastSaveTime;
+        return (_saveIntervalMinutes * 60f) - timeSinceLastSave;
+    }
+
+    private void OnEditorUpdate()
+    {
+        if (!_isAutoSaveEnabled || EditorApplication.isPlaying || EditorApplication.isCompiling)
+            return;
+
+        double timeRemaining = GetTimeRemaining();
+
+        if (timeRemaining <= 0)
+        {
+            ExecuteSave();
+        }
+
+        // 초 단위 바뀔 때만 UI 갱신
+        int currentSeconds = Mathf.CeilToInt((float)timeRemaining);
+        if (currentSeconds != _lastDisplayedSeconds)
+        {
+            _lastDisplayedSeconds = currentSeconds;
+            Repaint(); 
+        }
+    }
+
+    private void ExecuteSave()
+    {
+        if (EditorSceneManager.SaveOpenScenes())
+        {
+            Logger.Log($"<color=#00FF00><b>[AutoSave]</b></color> Scene auto-save complete! (period: {_saveIntervalMinutes}minutes)");
+        }
+        _lastSaveTime = EditorApplication.timeSinceStartup;
+    }
+}

--- a/Assets/Editor/AutoSaveTool.cs.meta
+++ b/Assets/Editor/AutoSaveTool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 08c5903cb33094bf598edcfc4e815af7


### PR DESCRIPTION
## 개요
씬(Scene) 데이터가 수동으로 저장하지 않아 작업물이 유실되는 문제를 해결하기 위해 커스텀 에디터 툴을 제작했습니다. 

> Resolves #31  

## 작업 내용

### 1. AutoSaveTool 핵심 기능 구현 (Editor)
- `Tools -> Auto Save Settings` 메뉴로 접근가능한 커스텀 에디터 윈도우 생성.
- `EditorApplication.update` 이벤트 루프를 이용해 게임 플레이나 컴파일 중이 아닐 때만 안전하게 백그라운드에서 씬을 저장.
- 유니티를 재시작해도 설정이 유지되도록 `EditorPrefs` 기반 영구 저장 연동.

### 2. 추가 리팩토링
- **에디터로 인한 렉 차단**: 매 프레임 실행되는 `Repaint()`를 `Mathf.CeilToInt`로 캐싱하여 타이머의 '초(Second)'가 바뀔 때만 화면을 갱신하도록 수정

## 테스트 계획
**준비**
1. 에디터 최상단 메뉴에서 `Tools -> Auto Save Settings` 클릭하여 툴 오픈.
2. Project Settings -> Player -> Scripting Define Symbols에 `DEV_VER`이 정상 등록되어 있는지 확인 (`Logger.Log` 출력용).

**검증 절차**
1. **타이머 갱신 확인**: UI 하단에 '다음 자동 저장까지: OO초' 카운트다운이 정상적으로 작동하는지 확인.
2. **자동 저장 검증**: 주기를 1분으로 설정하고 대기했을 때 1분 뒤 에디터 콘솔 창에 씬 자동 저장 성공 로그가 출력되는지 확인.
3. **상태 변경 확인**: 체크박스를 해제했을 때 타이머가 즉시 멈추고 정지 상태로 변하는지 확인.
4. **저장 상태 유지**: 주기 변경 후 툴 창을 원하는 곳에 도킹해두고, 유니티 에디터를 껐다가 다시 켰을 때 변경한 주기 값이 정상적으로 로드되는지 확인.
5. **예외 상황 검증**: 게임이 플레이 중이거나 스크립트를 수정해 컴파일 중일 때는 타이머가 지나도 강제로 저장되지 않는지 확인.