### PR TITLE
[Fix] 병합 튕김 현상 수정 및 스폰 스케일 연출 적용

### DIFF
--- a/Assets/Scripts/Collision/Ball.cs
+++ b/Assets/Scripts/Collision/Ball.cs
@@ -1,5 +1,6 @@
 using JusticeScale.Scripts.Scales;
 using UnityEngine;
+using System.Collections;
 
 
 public class Ball : MonoBehaviour
@@ -13,9 +14,17 @@ public class Ball : MonoBehaviour
     public Scale CurrentScale { get; private set; }
     public bool IsMerging { get; private set;}
 
+    private Vector3 _originalScale;
+
     private void Awake()
     {
         Rigidbody  = GetComponent<Rigidbody>();
+        _originalScale = transform.localScale;
+
+        if(Rigidbody != null)
+        {
+            Rigidbody.maxDepenetrationVelocity = 2f;
+        }
     }
 
     private void OnEnable()
@@ -28,11 +37,45 @@ public class Ball : MonoBehaviour
             Rigidbody.linearVelocity = Vector3.zero;
             Rigidbody.angularVelocity = Vector3.zero;
         }
+        
+        // collider 재활성화
+        Collider col = GetComponent<Collider>();
+        if (col != null)
+        {
+            col.enabled = true;
+        }
     }
+
+
 
     public void SetMerging(bool state)
     {
         IsMerging = state;
+    }
+
+    public void StartMergeGrouth()
+    {
+        StartCoroutine(GrowUpRoutine());
+    }
+
+    private IEnumerator GrowUpRoutine()
+    {
+        float duration = 0.15f;
+        float elapsed = 0f;
+
+        // 시작 크기를 0.5배 정도로 아주 작게 시작
+        Vector3 startScale = _originalScale * 0.5f; 
+        transform.localScale = startScale;
+
+        while (elapsed < duration)
+        {
+            elapsed += Time.deltaTime;
+            // 부드러운 팽창 (Lerp)
+            transform.localScale = Vector3.Lerp(startScale, _originalScale, elapsed / duration);
+            yield return null;
+        }
+
+        transform.localScale = _originalScale;
     }
 
     public void SetScale(Scale scale)

--- a/Assets/Scripts/Managers/MergeManager.cs
+++ b/Assets/Scripts/Managers/MergeManager.cs
@@ -10,6 +10,9 @@ public class MergeManager : SingletonBehaviour<MergeManager>
         firstBall.SetMerging(true);
         secondBall.SetMerging(true);
 
+        firstBall.GetComponent<Collider>().enabled = false;
+        secondBall.GetComponent<Collider>().enabled = false;
+
         // 충돌 지점 계산
         Vector3 spawnPos = (firstBall.transform.position + secondBall.transform.position) / 2f;
 
@@ -17,6 +20,9 @@ public class MergeManager : SingletonBehaviour<MergeManager>
         {
             int nextLevel = firstBall.ballLevel + 1;
             PoolType nextPoolType = firstBall.nextLevelPrefab.GetComponent<Ball>().myPoolType;
+
+            PoolManager.Instance.ReturnObject(firstBall.myPoolType, firstBall.gameObject);
+            PoolManager.Instance.ReturnObject(secondBall.myPoolType, secondBall.gameObject);
 
             if (AudioManager.Instance != null)
             {   
@@ -26,6 +32,8 @@ public class MergeManager : SingletonBehaviour<MergeManager>
 
             if (newBall != null)
             {
+                newBall.StartMergeGrouth();
+
                 BallCollisionSensor sensor = newBall.GetComponent<BallCollisionSensor>();
 
                 if(sensor != null && firstBall.CurrentScale != null)
@@ -41,7 +49,11 @@ public class MergeManager : SingletonBehaviour<MergeManager>
                 }
             }
         }
-        PoolManager.Instance.ReturnObject(firstBall.myPoolType, firstBall.gameObject);
-        PoolManager.Instance.ReturnObject(secondBall.myPoolType, secondBall.gameObject);
+        else
+        {
+            PoolManager.Instance.ReturnObject(firstBall.myPoolType, firstBall.gameObject);
+            PoolManager.Instance.ReturnObject(secondBall.myPoolType, secondBall.gameObject);
+        }
+        
     }
 }


### PR DESCRIPTION
## 개요
'물리적 관통 해소(Depenetration)에 의한 연쇄 폭발 현상'을 해결했습니다. 공이 합쳐질 때 로직 순서를 교정하여 물리 중첩을 막았습니다. 그리고 최대 반발 속도 제한과 부드러운 부피 팽창 애니메이션을 도입하여 공의 밀도가 높은 상황에서도 안정적인 플레이가 가능해졌습니다.

> Resolves #33 

## 작업 내용

### 1. 물리 엔진 중첩 차단
- `MergeManager.cs` : 두 공이 병합될 때 기존 공들의 `Collider`를 끄고 풀에 먼저 반납한 뒤, 빈 공간에 새 공을 소환하도록 실행 순서를 교정.
- `Ball.cs` : 풀링 시스템 재사용 시 튕겨 나가는 관성을 없애기 위해  `linearVelocity`와 `angularVelocity`를 `Vector3.zero`로 초기화하고 `Collider`를 다시 활성화하도록 설정.

### 2. 2차 연쇄 폭발 방지
- **최대 반발력 제어**: `Ball.cs`의 `Awake`에서 `Rigidbody.maxDepenetrationVelocity`를 설정하여 다른 공과 겹치더라도 튕겨 나가지 않고 부드럽게 밀려나도록 구현.
- **부드러운 팽창 연출**: 새 공이 소환될 때 즉시 100% 크기로 나타나 주변 공과 충돌하는 것을 방지하기 위해 초기 크기를 0.5배로 낮춘 후 0.15초에 걸쳐 부드럽게 부풀어 오르는 코루틴 연출을 추가했습니다.

## 테스트 계획
**준비**
1. 에디터에서 `InGame` 씬(또는 테스트 씬)을 엽니다.

**검증 절차**
1. **폭발 방지** : 여러 개의 공이 존재하는 상태로 공을 병합할 때, 공들이 화면 밖으로 튕겨 나가는 현상이 완전히 사라졌는지 확인합니다.
2. **팽창 연출** : 병합되어 나타난 새로운 공이 아주 작게 소환된 직후, 부드럽게 부피가 커지는지 육안으로 확인합니다.
3. **부드러운 밀어내기** : 새 공이 팽창함에 따라 주변에 있던 다른 공들이 튀지 않고 자연스럽게 옆으로 밀려나는 조작감을 확인합니다.
4. **풀링 재활용 검증** : 병합으로 인해 반납되었던 공이 다시 화면 상단에서 스폰될 때, 콜라이더가 정상 작동하며 잔존하는 물리 속도 없이 수직으로 잘 떨어지는지 확인합니다.